### PR TITLE
set routes to remove # from url

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -3,17 +3,20 @@
         <nav class="navnbar navbar-expand-lg navbar-light">
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav mr-auto">
-                    <li class="nav-item active">
-                        <router-link to="/"><a href="" class="nav-link">home</a></router-link>
-                    </li>
-                    <li class="nav-item">
-                        <router-link to="/menu"><a href="" class="nav-link">menu</a></router-link>
-                    </li>
-                    <li class="nav-item">
-                       <router-link to="/admin"><a href="" class="nav-link">admin</a></router-link>
-                    </li>
+                    <router-link to="/" tag="li"><a href="" class="nav-link">home</a></router-link>
+                    <router-link to="/menu" tag="li"><a href="" class="nav-link">menu</a></router-link>
+                    <router-link to="/admin" tag="li"><a href="" class="nav-link">admin</a></router-link>
                 </ul>
             </div>
         </nav>
     </footer>
 </template>
+<script>
+export default {
+    data(){
+        return{
+            
+        }
+    }
+}
+</script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,17 +4,23 @@
             <a href="/" class="navbar-brand">PIZZA PLANET</a>
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav mr-auto">
-                    <li class="nav-item active">
-                        <router-link to="/"><a href="" class="nav-link">home</a></router-link>
-                    </li>
-                    <li class="nav-item">
-                         <router-link to="/menu"><a href="" class="nav-link">menu</a></router-link>
-                    </li>
+                    <router-link :to="homeLink" tag="li"><a href="" class="nav-link">home</a></router-link>
+                    <router-link :to="menuLink" tag="li"><a href="" class="nav-link">menu</a></router-link>
                 </ul>
             </div> 
         </nav>
     </header>
 </template>
+<script>
+export default {
+    data(){
+        return{
+            homeLink: '/',
+            menuLink: '/menu'
+        }
+    }
+}
+</script>
 <style>
     header{
         margin-bottom: 20px;

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,10 @@ const routes =[
   }
 ]
 const router = new VueRouter({
-  routes
+  //history mode takes advantage of html5 history api.
+  //this allows us to load url without refreshing page. 
+  routes,
+  mode: 'history'
 })
 new Vue({
   el: '#app',


### PR DESCRIPTION
On this branch, we have set up Routes mode to history, since it make  a use of html5 history api.
This allows us to load url without page refresh, removes the default behaviour of browser which adds the # at the end.